### PR TITLE
Fix album back image and platz box display

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,10 +23,10 @@
     .flip-card{width:100%;height:100%}
     .flip-card-inner{position:relative;width:100%;height:100%;transform-style:preserve-3d;transition:transform .5s ease;box-shadow:0 10px 30px rgba(0,0,0,.5);border-radius:18px;will-change:transform;overflow:hidden}
     .flip-card-inner.is-flipped{transform:rotateY(180deg)}
-    .face{position:absolute;inset:0;border-radius:18px;overflow:hidden;background:#000;backface-visibility:hidden}
+    .face{position:absolute;inset:0;border-radius:18px;overflow:hidden;background:#000;backface-visibility:hidden;-webkit-backface-visibility:hidden}
     .back{transform:rotateY(180deg)}
-    .face img{width:100%;height:100%;object-fit:cover}
-    .platz{position:absolute;top:14px;left:14px;right:14px;z-index:2;background:rgba(0,0,0,.6);color:#fff;font-weight:800;font-size:1.1rem;padding:6px 10px;border-radius:12px;user-select:none;pointer-events:none;display:inline-block;max-width:unset;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .face img{width:100%;height:100%;object-fit:cover;backface-visibility:hidden;-webkit-backface-visibility:hidden}
+
     .swiper-button-next,.swiper-button-prev{color:var(--accent);--swiper-navigation-size:2.6rem}
   </style>
 </head>
@@ -84,7 +84,6 @@
           <div class="flip-card" role="button" aria-label="Album umdrehen" tabindex="0">
             <div class="flip-card-inner">
               <div class="face front">
-                <span class="platz">Platz ${platzLabel}</span>
                 <img src="${a.front}" alt="Cover Platz ${platzLabel}" loading="lazy" decoding="async">
               </div>
               <div class="face back">


### PR DESCRIPTION
Fix album image flip to show actual back image and move "Platz" box above images.

The flip issue was due to missing `-webkit-backface-visibility` on image elements, causing the back of the front image to be visible instead of the true back image. The "Platz" box overlay was removed from the image as it is already displayed in the header.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7b75fe8-28f5-4e99-9585-44e704ad7a1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7b75fe8-28f5-4e99-9585-44e704ad7a1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

