### PR TITLE
Fix background image display on cover touch

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,12 +19,12 @@
     .swiper{width:90vw;max-width:60vh;aspect-ratio:1/1}
     @media (max-width:768px){.swiper{width:88vw;max-width:88vw}}
     .swiper{touch-action:pan-y}
-    .swiper-slide{perspective:1500px;background:transparent;display:grid;place-items:center;will-change:transform;contain:layout paint}
-    .flip-card{width:100%;height:100%}
-    .flip-card-inner{position:relative;width:100%;height:100%;transform-style:preserve-3d;transition:transform .5s ease;box-shadow:0 10px 30px rgba(0,0,0,.5);border-radius:18px;will-change:transform;overflow:hidden}
-    .flip-card-inner.is-flipped{transform:rotateY(180deg)}
-    .face{position:absolute;inset:0;border-radius:18px;overflow:hidden;background:#000;backface-visibility:hidden;-webkit-backface-visibility:hidden}
-    .back{transform:rotateY(180deg)}
+    .swiper-slide{background:transparent;display:grid;place-items:center;will-change:transform;contain:layout paint}
+    .flip-card{width:100%;height:100%;perspective:1200px;border-radius:18px;overflow:hidden;box-shadow:0 10px 30px rgba(0,0,0,.5)}
+    .flip-card-inner{position:relative;width:100%;height:100%;transform-style:preserve-3d;-webkit-transform-style:preserve-3d;transition:transform .5s ease;will-change:transform}
+    .flip-card-inner.is-flipped{transform:rotateY(180deg);-webkit-transform:rotateY(180deg)}
+    .face{position:absolute;inset:0;background:#000;backface-visibility:hidden;-webkit-backface-visibility:hidden}
+    .back{transform:rotateY(180deg);-webkit-transform:rotateY(180deg)}
     .face img{width:100%;height:100%;object-fit:cover;backface-visibility:hidden;-webkit-backface-visibility:hidden}
 
     .swiper-button-next,.swiper-button-prev{color:var(--accent);--swiper-navigation-size:2.6rem}


### PR DESCRIPTION
Fixes card flip animation to correctly display back images by adjusting CSS 3D perspective and adding WebKit prefixes.

The original CSS placed `perspective` on `.swiper-slide`, which interfered with Swiper's own transformations for the "cards" effect, preventing the backface from rendering correctly. Relocating `perspective` to the stable `.flip-card` wrapper and adding `-webkit-` prefixes resolves these 3D rendering glitches, ensuring the back image is visible upon flip.

---
<a href="https://cursor.com/background-agent?bcId=bc-a38c50a0-f411-4f24-8817-cc2ae22988fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a38c50a0-f411-4f24-8817-cc2ae22988fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

